### PR TITLE
Added a new configuration: full_tag (editable in config.json).

### DIFF
--- a/echelon/__init__.py
+++ b/echelon/__init__.py
@@ -3,7 +3,8 @@ from aqt import mw
 config = mw.addonManager.getConfig(__name__)
 
 # Separator used between hierarchies
-SEPARATOR = config['separator']
-
+SEPARATOR = config["separator"]
+# Display full tag name (with parents and Separator) or only the sub-tag
+FULL_TAG = config["full_tag"]
 
 from . import echelon

--- a/echelon/config.json
+++ b/echelon/config.json
@@ -1,3 +1,4 @@
 {
-    "separator": "::"
+    "separator": "::",
+    "full_tag": false
 }

--- a/echelon/echelon.py
+++ b/echelon/echelon.py
@@ -3,7 +3,7 @@ from aqt.browser import Browser
 from aqt.qt import QIcon, QAction, QMenu, QCursor, QInputDialog, QLineEdit, QMessageBox
 from anki.hooks import wrap
 
-from . import SEPARATOR
+from . import SEPARATOR, FULL_TAG
 from .rename import rename, verify
 
 
@@ -25,11 +25,20 @@ def _userTagTree(self, root, _old):
             parent = tags_tree[genParent(t)]
 
         item = self.CallbackItem(
-            parent, t,
+            parent, formatted(t),
             fil_func)
         item.setIcon(0, QIcon(":/icons/tag.svg"))
 
         tags_tree[t] = item
+
+
+def formatted(tag):
+    if FULL_TAG:
+        # full tag with parents and sep
+        return tag
+    else:
+        # only last sub-tag
+        return tag.split(SEPARATOR)[-1]
 
 
 def isParent(tag):


### PR DESCRIPTION
If true, tags are displayed as previously:
Parent
    Parent::Child
If false, only sub-tags are displayed in the browser:
Parent
    Child