### PR TITLE
Fix typo in rename.py

### DIFF
--- a/echelon/rename.py
+++ b/echelon/rename.py
@@ -32,7 +32,7 @@ def rename(old_name, new_name):
     mw.progress.finish()
 
 def verify(name):
-    SEPARAOR = get_config()["separator"]
+    SEPARATOR = get_config()["separator"]
     if name.endswith(SEPARATOR):
         return False
     if name.startswith(SEPARATOR):


### PR DESCRIPTION
Hello :slightly_smiling_face: 
I had an issue with the addon (Anki showed error every time I tried to rename a tag) and found out that there is a typo in `SEPARATOR` constant in `rename.py`